### PR TITLE
Hotfix: Fixes a broken import for Sirius >=7.0.0

### DIFF
--- a/org.emoflon.ibex.tgg.editor.diagram.core/src/org/emoflon/ibex/tgg/editor/diagram/core/AnalysisResourceReloadedCommand.java
+++ b/org.emoflon.ibex.tgg.editor.diagram.core/src/org/emoflon/ibex/tgg/editor/diagram/core/AnalysisResourceReloadedCommand.java
@@ -19,7 +19,7 @@ import org.eclipse.emf.transaction.RecordingCommand;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.sirius.business.internal.session.danalysis.DAnalysisSessionImpl;
 import org.eclipse.sirius.viewpoint.DAnalysis;
-import org.eclipse.sirius.viewpoint.Messages;
+import org.eclipse.sirius.tools.api.Messages;
 
 import com.google.common.base.Preconditions;
 


### PR DESCRIPTION
In 2022-02, `eclipse-sirius 7.0.0` was released (https://projects.eclipse.org/projects/modeling.sirius/releases/7.0.0).
The release notes include a renaming of the class `Messages` that this project uses (https://projects.eclipse.org/projects/modeling.sirius/releases/7.0.0):

![image](https://user-images.githubusercontent.com/20956405/169842934-4cc82bdd-d5ab-4977-b43f-138443ce782a.png)

Because `eclipse-sirius` in version `>=7.0.0` is the default version in EMT `2022-03`, I've adapted the renaming of Sirius in this project.

@Arikae: Can you please check if the graphical TGG editor works as intended? You can use [this Eclipse 2022-03 CI build](https://github.com/maxkratz/emoflon-eclipse-build/suites/6593661820/artifacts/247466845) to check out the dev-ws and use my PR in `emoflon-ibex-sirius` (= this repository).

(Btw, I can use the graphical editor in my runtime test workspace.)

![image](https://user-images.githubusercontent.com/20956405/169843614-af96673a-502b-4e9b-8899-3ee6a2dc1e3b.png)
